### PR TITLE
Merge env setup from back-feat-ps-redis to back

### DIFF
--- a/microblog/backend/config/__init__.py
+++ b/microblog/backend/config/__init__.py
@@ -1,0 +1,3 @@
+from .celery import app as celery_app
+
+__all__ = ('celery_app')

--- a/microblog/backend/config/celery.py
+++ b/microblog/backend/config/celery.py
@@ -1,0 +1,10 @@
+import os
+from celery import Celery
+from django.conf import settings
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+
+app = Celery('config')
+app.config_from_object('django.conf:settings', namespace='CELERY')
+app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+

--- a/microblog/backend/config/settings.py
+++ b/microblog/backend/config/settings.py
@@ -12,10 +12,13 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 import os
 from pathlib import Path
 from datetime import timedelta
+from pathlib import Path
 import environ
+
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+
 
 
 # Quick-start development settings - unsuitable for production
@@ -28,6 +31,12 @@ SECRET_KEY = 'django-insecure-rn21&xzf9$@pn#t#6cyu@a(bon4imc^)o)&2pa^)i6qgns6m_)
 DEBUG = True
 
 ALLOWED_HOSTS = []
+
+# django-environ 초기화
+env = environ.Env(
+    DEBUG=(bool, False) # 타입 및 기본값 지정(선택)
+)
+environ.Env.read_env(os.path.join(BASE_DIR, '.env'))
 
 
 # Application definition
@@ -110,12 +119,6 @@ WSGI_APPLICATION = 'config.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 
-# django-environ 초기화
-env = environ.Env(
-    DEBUG=(bool, False) # 타입 및 기본값 지정(선택)
-)
-
-environ.Env.read_env(os.path.join(BASE_DIR, '.env'))
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
@@ -130,6 +133,15 @@ DATABASES = {
         }
     }
 }
+
+# Celery 설정 
+CELERY_BROKER_URL = env('CELERY_BROKER_URL')
+CELERY_RESULT_BACKEND = env('CELERY_RESULT_BACKEND')
+
+# Optional: 작업 결과 JSON 직렬화
+CELERY_TASK_SERIALIZER = 'json'
+CELERY_RESULT_SERIALIZER = 'json'
+CELERY_ACCEPT_CONTENT = ['json']
 
 
 # Password validation

--- a/microblog/backend/requirements.txt
+++ b/microblog/backend/requirements.txt
@@ -38,7 +38,7 @@ PyYAML==6.0.2
 referencing==0.36.2
 regex==2024.11.6
 requests==2.32.4
-requests-oauthlib==2.0.0
+requests-oauthlib==2.0.
 rpds-py==0.26.0
 setuptools==78.1.1
 six==1.17.0

--- a/microblog/backend/requirements.txt
+++ b/microblog/backend/requirements.txt
@@ -1,6 +1,7 @@
 asgiref==3.9.0
 attrs==25.3.0
 black==25.1.0
+celery==5.5.3
 certifi==2025.7.14
 cffi==1.17.1
 charset-normalizer==3.4.2
@@ -35,6 +36,7 @@ psycopg2-binary==2.9.10
 pycparser==2.22
 PyJWT==2.10.1
 PyYAML==6.0.2
+redis==6.2.0
 referencing==0.36.2
 regex==2024.11.6
 requests==2.32.4


### PR DESCRIPTION
## Summary
이 PR은 back-feat-ps-redis 브랜치의 **redis+celery 초기 환경 설정 작업을 back 브랜치에 병합합니다.

## Changes
- redis, celery, django-celery-results 라이브러리 설치
- docker-compose.yml에 redis-server 서비스 추가
- settings.py에 Celery 설정 (브로커: Redis, 백엔드 설정 포함)
- celery.py 생성 및 __init__.py에 celery 앱 등록

## Reason
향후 이메일 발송, 이미지 처리, 알림 등 **비동기 백그라운드 작업 구현을 위한 기반 구성**